### PR TITLE
docs: shorten README to 81 lines; drop Ollama (Lemonade-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,177 +1,81 @@
 # VSCodium-Rust
 
-A local-first, agentic IDE built with **Rust/Tauri v2** + **React 19/TypeScript/Vite**.
+A local-first, agentic IDE — **Rust/Tauri v2** backend, **React 19/TypeScript** frontend.
+The editor is VS Code–shaped; the agent loop, indexing, and process management run in a
+native process, not an Electron main thread.
 
 ![VSCodium-Rust](pics/1.png)
 
-> **Human-authored, AI-assisted.** Architecture, technical approach, and every
-> merge decision are human. AI is used to generate code under that direction, and
-> every generated line is reviewed, tested against real hardware, and approved by a
-> human before it lands — feature by feature. See [How this was built](#how-this-was-built).
+> **Human-authored, AI-assisted.** Architecture, technical approach, and every merge
+> decision are human. AI generates code under that direction; every generated line is
+> reviewed and tested against real hardware before it lands, feature by feature.
 
----
+## What you get
 
-## What this is
-
-An IDE for people who run their models locally and drive them with agents. The
-editor is VS Code–shaped; the backend is a native Rust/Tauri process, so the
-agent loop, indexing, and process management don't run on an Electron main thread.
-
-- **Local inference, Lemonade-first.** Primary provider is
-  [Lemonade](https://github.com/lemonade-sdk/lemonade) — an OpenAI-compatible
-  server (`:13305`) tuned for local hardware (AMD included); Ollama (`:11434`) is
-  a fallback. Requests can route through the in-process **kortex** retrieval proxy
-  (`:1536`), which augments prompts with `.aim` workspace context.
-- **Agentic by default.** Multi-turn tool loop with verify-before-done, a shadow
-  workspace for safe edits, and background agents for long-running work.
-- **Local-first.** Code and model traffic stay on your machine unless you point a
+- **Local inference via [Lemonade](https://github.com/lemonade-sdk/lemonade)** — an
+  OpenAI-compatible server (`:13305`) running real llama.cpp, tuned for local hardware
+  (AMD included). It's the only backend; bring your own API key for a hosted model if
+  you want one. Prompts can route through the in-process **kortex** proxy (`:1536`),
+  which injects `.aim` workspace context.
+- **Agentic by default** — multi-turn tool loop with verify-before-done, a shadow
+  workspace for safe edits, background agents for long work.
+- **Local-first** — code and model traffic stay on your machine unless you point a
   provider at a remote endpoint.
-- **Security & ML tooling** in-IDE (offensive tooling, browser automation, PyTorch
-  training) for research workflows.
+- **Editor** — Monaco, FIM tab-autocomplete, inline agent-edit diff with per-hunk
+  accept/reject, Git status/diff/commit.
+- **Code intelligence** — vector semantic search, symbol + chunk index, LSP
+  diagnostics, distilled knowledge briefs.
+- **Security & ML** — APEX specialist routing, headless-browser automation, secret
+  scanning, PyTorch train loop + ONNX export.
+- **iOS on Windows/Linux** — ARM64 Mach-O compile, `.ipa` packaging, `zsign`/`ldid`
+  signing, `go-ios` install — no macOS/Xcode. See [`docs/mobile.md`](docs/mobile.md)
+  (`iPhoneOS.sdk` is the one asset you supply yourself).
 
-It is an active project, not a finished product.
+## Quick start
 
----
-
-## Features
-
-| Area | Highlights |
-|------|-----------|
-| **AI agent** | Autonomous tool loop with verify-before-done · thinking protocol · FastContext repo-exploration subagent · shadow workspace · background agents · tool-permission gate · MCP client + server · `.cursor/rules` |
-| **Editor** | Monaco · FIM tab-autocomplete · inline agent-edit diff with per-hunk accept/reject · selection-scoped quick edit · Git status/diff/commit/branches |
-| **Code intelligence** | Vector semantic search (Ollama embeddings) · symbol + chunk index · LSP diagnostics · distilled knowledge briefs |
-| **Security research** | APEX 7-model specialist routing · headless-Firefox browser automation · pentest tooling · entropy-based secret scanning |
-| **ML studio** | PyTorch train loop + loss curves · model hub (torchvision/timm/HF) · Optuna HPO · ONNX export |
-| **iOS on Windows/Linux** | ARM64 Mach-O compile · Dart→Mach-O AOT · `.ipa` packaging · `zsign`/`ldid` signing · `go-ios` install + launch — no macOS/Xcode. See [`docs/mobile.md`](docs/mobile.md). |
-
-`iPhoneOS.sdk` is the one asset that can't be redistributed — supply your own via
-`SDKROOT` or the in-app **Import SDK**.
-
----
-
-## Getting started
-
-**Prerequisites:** Node.js 18+ · Rust toolchain (rustup) · a local model backend (Lemonade or Ollama)
+**Prerequisites:** Node.js 18+ · Rust (rustup) · [Lemonade](https://github.com/lemonade-sdk/lemonade)
 
 ```bash
 git clone https://github.com/H4D3ZS/vscodium-rust.git
 cd vscodium-rust
-git submodule update --init --recursive   # kortex, turbovec
+git submodule update --init --recursive    # kortex, turbovec
 npm install
+
+lemonade pull Huihui-gemma-4-12B-agentic-abliterated-i1-Q4_K_M   # best all-round agent model
+lemonade serve                                                    # :13305
+
+npm run dev:tauri     # full IDE   (npm run dev = frontend only, npx tauri build = release)
 ```
 
-```bash
-npm run dev          # frontend dev server
-npm run dev:tauri    # full IDE (Tauri app)
-npx tauri build      # production build
-cd src-tauri && cargo check
-```
-
-macOS build notes: [`docs/build-macos.md`](docs/build-macos.md).
-Release/installer: [`docs/release.md`](docs/release.md).
-
-### AI agent setup
-
-Lemonade runs llama.cpp directly:
-
-```bash
-# Best measured all-round agent model (30 tok/s, 8/8 tool calls)
-lemonade pull Huihui-gemma-4-12B-agentic-abliterated-i1-Q4_K_M
-# Stronger reasoning for long autonomous runs (16 tok/s, ~11k usable context)
-lemonade pull Qwen3.6-35B-A3B-Abliterated-Heretic-GGUF-Q4_K_M
-lemonade serve       # :13305
-```
-
-Avoid 2-bit quants — measured 0/6 on tool calling and 2.5–4× slower (compute-bound, not bandwidth-bound).
-Open the IDE, pick the model in the agent toolbar, start coding.
-
----
+Avoid 2-bit quants — measured 0/6 on tool calling and 2.5–4× slower.
+macOS: [`docs/build-macos.md`](docs/build-macos.md) · Release: [`docs/release.md`](docs/release.md).
 
 ## Architecture
 
-Clean/DDD layering on both sides — `domain → application → infrastructure`, plus
-`presentation` on the frontend — enforced by `scripts/check-architecture.mjs`.
-
-```
-src/                 React 19 + TypeScript
-  domain/            entities, value objects, repository ports (no React, no Tauri)
-  application/       use-cases (one file per user goal)
-  infrastructure/    Tauri IPC adapters, lazy legacy engines
-  components/        React UI — calls application layer, never invoke() directly
-  store/             Zustand slices
-src-tauri/src/       Rust (Tauri v2)
-  domain/            ai · tools · vcs · security · indexing · memory · editor · mobile · extensions
-  application/       thin #[tauri::command] adapters (the one invoke_handler! in lib.rs)
-  infrastructure/    process spawning, HTTP, FFI, git2, tree-sitter
-kortex/  (submodule) retrieval proxy · .aim binary format · daemon
-turbovec/ (submodule) vector kernels
-```
-
-Full map and the conventions every change follows: [`ARCHITECTURE.md`](ARCHITECTURE.md).
-
----
+Clean/DDD layering on both sides (`domain → application → infrastructure`, plus
+`presentation` on the frontend), enforced by `scripts/check-architecture.mjs`.
+Full map and conventions: [`ARCHITECTURE.md`](ARCHITECTURE.md) · frontend entry
+points: [`src/README.md`](src/README.md).
 
 ## Testing
 
 ```bash
-npm test                       # frontend unit + architecture check
-npm run typecheck
-cd src-tauri && cargo test      # backend
+npm test && npm run typecheck         # frontend + architecture check
+cd src-tauri && cargo test            # backend
 ```
-
----
-
-## How this was built
-
-This project is AI-assisted, and it's worth being precise about which parts,
-because the distinction matters.
-
-**Human — everything that decides what the software is:**
-
-- System architecture and module boundaries
-- Every technical approach and the judgement behind it
-- Design review and approval of each change before it lands
-- Correctness review, cleanup, and stabilisation of generated code
-- Debugging against real hardware, where the actual problems live
-
-**AI — code generation under direction:**
-
-- Boilerplate and scaffolding from a specified design
-- Mechanical refactors across many files
-- First-draft implementations of already-decided approaches
-- Docstrings and comments, edited by hand afterwards
-
-The load-bearing insights here were human. The host-native iOS toolchain — that
-Apple's compilers were never the macOS-only part, that only packaging is — was a
-human call, made against an assistant that had twice asserted it was impossible
-and once insisted it needed cloud builds. It took human pushback and a direct
-experiment to settle.
-
-Every generated line was read, corrected, tested against real hardware, and
-approved by a human before merge — which is why the suite is green and the
-failure modes are documented rather than discovered by users. If you use AI on
-your own projects, this is the split worth copying: let it write what you've
-already decided, and never let it decide.
-
----
 
 ## Contributing
 
-1. Fork, branch, change.
-2. `npm test && npm run typecheck` and `cd src-tauri && cargo test`.
-3. Keep patches surgical (`patch_engine` / `diffy`) — no full-file rewrites.
-4. Follow [`ARCHITECTURE.md`](ARCHITECTURE.md): logic in engines, thin commands, no `invoke()` in components.
-5. Open a PR — every feature is reviewed per code and per behaviour before merge.
-
----
+Fork, branch, change. Run the tests above. Keep patches surgical (no full-file
+rewrites), logic in engines, thin commands, no `invoke()` in components — see
+[`ARCHITECTURE.md`](ARCHITECTURE.md). Every feature is reviewed per code and per
+behaviour before merge.
 
 ## License
 
-MIT — see [LICENSE](LICENSE). Bundled/adjacent components keep their own licenses
-(`claurst` GPL, kept at a process boundary).
-
-## Acknowledgments
-
-[VSCodium](https://vscodium.com/) · [Tauri](https://tauri.app/) ·
-[Lemonade](https://lemonade-server.ai/) · [go-ios](https://github.com/danielpaulus/go-ios) ·
-[ldid](https://github.com/ProcursusTeam/ldid) · [Monaco Editor](https://microsoft.github.io/monaco-editor/)
+MIT — see [LICENSE](LICENSE). `claurst` is GPL, kept at a process boundary.
+Built on [VSCodium](https://vscodium.com/), [Tauri](https://tauri.app/),
+[Lemonade](https://github.com/lemonade-sdk/lemonade),
+[go-ios](https://github.com/danielpaulus/go-ios),
+[ldid](https://github.com/ProcursusTeam/ldid),
+[Monaco](https://microsoft.github.io/monaco-editor/).

--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -34,7 +34,7 @@ npm run build && npx tauri build
 ## Mac specifics (vs Windows)
 - **Renderer:** macOS uses the built-in **WKWebView** — no WebView2 to install/bundle. The `webviewInstallMode` config is under `bundle.windows`, so it's ignored on Mac. (Same Chromium-vs-WebKit caveat: WKWebView is lighter than Windows' Chromium, so memory is generally lower on Mac.)
 - **Terminal:** `default_consumer_shell()` is `cfg(windows)`-gated for Git Bash; on macOS it uses `$SHELL` (zsh on modern macOS). No Git Bash bundling needed.
-- **Local AI on M1:** use **Ollama** (Metal-accelerated) or the cloud gate. `lemonade` is AMD/x86-oriented — don't expect it to run local models on Apple Silicon; point the model picker at Ollama or `ai.cyberifrit.xyz`.
+- **Local AI on M1:** Lemonade is AMD/x86-oriented and won't run local models well on Apple Silicon — on M1, point the model picker at a hosted model with your own API key, or run `llama.cpp` (Metal) directly and set it as an OpenAI-compatible endpoint.
 - **Code signing / Gatekeeper:** `tauri.conf.json` sets `macOS.signingIdentity: "Apple Development"`. For local testing that's fine; if Gatekeeper blocks the `.app`, right-click → Open, or `xattr -dr com.apple.quarantine <App>.app`. For distribution you need a real **Developer ID** cert + notarization.
 - **tree-sitter-typescript** is pinned to `=0.23.0` for a Windows/MSVC reason — it compiles fine on Mac; leave the pin.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -88,7 +88,7 @@ Or set Tauri's `bundle.windows.certificateThumbprint` to sign during `tauri buil
 
 ## 5. Host + link on the website
 
-The IDE is **free to download** (works with local Ollama + your own API keys).
+The IDE is **free to download** (works with local Lemonade + your own API keys).
 Payment unlocks **Cyber-Ifrit Cloud** managed models (enforced in-app + at the AMD
 gateway). So the download link is public:
 
@@ -149,7 +149,7 @@ Both sidecars are built automatically by `npm run prebuild:sidecar` (runs before
 
 ## Optional services (user machine)
 
-- **Ollama** `:11434` — local models
+- **Lemonade** `:13305` — local models (real llama.cpp)
 - **aim-proxy** `:1536` — `.aim` context injection
 - Cloud keys in Settings → Providers
 


### PR DESCRIPTION
Follow-up to #212 — this commit was pushed to the port branch **after** #212 was merged, so it didn't land.

- **README 177 → 81 lines** — feature list collapsed, quick-start is Lemonade `pull` + `serve` only.
- **Ollama removed from docs** — 0 mentions in README; `docs/build-macos.md` M1 note no longer points at Ollama or the `ai.cyberifrit.xyz` endpoint; `docs/release.md` `Ollama :11434` → `Lemonade :13305`.

Codebase-level Ollama removal (157 files) is still a separate effort; `docs/kortex-cache.md` keeps its backend-comparison content until then.
