### PR TITLE
docs(mobile): credit vphone-cli + darwin-vm; our Rust emulator is in-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ native process, not an Electron main thread.
   diagnostics, distilled knowledge briefs.
 - **Security & ML** — APEX specialist routing, headless-browser automation, secret
   scanning, PyTorch train loop + ONNX export.
-- **iOS on Windows/Linux** — ARM64 Mach-O compile, `.ipa` packaging, `zsign`/`ldid`
-  signing, `go-ios` install — no macOS/Xcode. See [`docs/mobile.md`](docs/mobile.md)
-  (`iPhoneOS.sdk` is the one asset you supply yourself).
+- **iOS build on Windows/Linux** — ARM64 Mach-O compile, `.ipa` packaging,
+  `zsign`/`ldid` signing, `go-ios` install — no macOS/Xcode (`iPhoneOS.sdk` is the
+  one asset you supply). The iPhone **emulator** is a separate in-progress Rust
+  component; on Apple Silicon the Devices panel drives
+  [vphone-cli](https://github.com/Lakr233/vphone-cli) /
+  [darwin-vm](https://github.com/jprx/darwin-vm) today. See [`docs/mobile.md`](docs/mobile.md).
 
 ## Quick start
 
@@ -79,3 +82,8 @@ Built on [VSCodium](https://vscodium.com/), [Tauri](https://tauri.app/),
 [go-ios](https://github.com/danielpaulus/go-ios),
 [ldid](https://github.com/ProcursusTeam/ldid),
 [Monaco](https://microsoft.github.io/monaco-editor/).
+
+iPhone emulation on Apple Silicon builds on two MIT projects — credit to their
+authors: [vphone-cli](https://github.com/Lakr233/vphone-cli) by
+[Lakr233](https://github.com/Lakr233), and
+[darwin-vm](https://github.com/jprx/darwin-vm) by [jprx](https://github.com/jprx).

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -1,139 +1,61 @@
-# Mobile Toolchain (Android + iPhone + vPhone)
+# Mobile toolchain (Android + iPhone)
 
-Integrated in **Devices** panel (right sidebar → DEVICES).
+Everything is driven from the **Devices** panel (right sidebar → DEVICES).
 
-## Tabs
+## Android
 
-| Tab | Purpose |
-|-----|---------|
-| **Android** | Launch AVD headless, embedded display via ADB screencap (`emulator:frame` events) |
-| **iPhone** | acheron / Virtual-iPhone-Emulator (user-provided firmware) |
-| **Toolchain** | vPhone phony-Xcode shims, `vphone-doctor`, AltStore deploy notes |
+Launch a headless AVD; the panel embeds the display via `start_emulator_stream` +
+`emulator:frame` events (using the SDK-resolved `adb.exe`, not bare `adb` on PATH).
+Tap the canvas to send `input tap`. First-time SDK setup: `install-android-sdk.ps1`.
 
-## Android emulator fix
+## iPhone
 
-The Devices panel now uses **`start_emulator_stream`** + **`emulator:frame`** (SDK-resolved `adb.exe`), not bare `adb` on PATH. Tap the canvas to send `input tap`.
+> **About our emulator.** VSCodium-Rust has its own iPhone emulator — a **Rust**
+> project (`src-tauri/src/iphone_emulator.rs` + `IPhoneEmulatorPanel.tsx`),
+> **still in development**. When it's finished it will be released publicly as its
+> own open-source component. Until then, use one of the tools below — the Devices
+> panel shells out to them.
 
-## vPhone toolchain
+### macOS, Apple Silicon (recommended)
 
-Set `VPHONE_ROOT` to your `Virtual-iPhone-Emulator` folder, or place it beside the IDE workspace.
+On an M-series Mac with **16–32 GB RAM** you can run a real iOS VM without Xcode:
 
-```powershell
-cd Virtual-iPhone-Emulator\toolchain
-install_doctor.bat
-vphone-doctor.bat
-```
+| Tool | What it gives you | License |
+|------|-------------------|---------|
+| **[vphone-cli](https://github.com/Lakr233/vphone-cli)** by [Lakr233](https://github.com/Lakr233) | A full iPhone emulator **with a UI** — the easiest path. | MIT |
+| **[darwin-vm](https://github.com/jprx/darwin-vm)** by [jprx](https://github.com/jprx) | iOS/macOS in **QEMU** (iPhone 12–17, M1–M5). **Root shell + terminal only**, no touch UI — good for headless/CI and low-level work. | MIT |
 
-Toolchain tab runs these from the IDE. Flutter/RN tooling sees phony Xcode + vPhone Bridge when doctor passes.
+Both are third-party MIT projects — install them yourself and point the Devices
+panel at the binary. We don't vendor or redistribute them; all credit to their
+authors.
 
-## AltStore
+### macOS, with full Xcode installed
 
-Not bundled (AGPL). Install [AltServer](https://github.com/altstoreio/AltStore) separately for `.ipa` sideload to physical devices.
+The **iPhone** tab can drive a headless **Xcode Simulator mirror** (no
+`Simulator.app` window) — `src-tauri/src/ios_simulator.rs` + `MacIOSSimulatorPanel`.
+Requires:
 
----
+- Full **Xcode** (not just Command Line Tools) — `sudo xcode-select -s /Applications/Xcode.app`
+- At least one iOS simulator runtime downloaded
 
-## iPhone emulator — setup & required files
+Open **Devices → iPhone → ▶ Mirror**. Helper binaries compile once into
+`~/Library/Caches/com.hades.vscode-rust-app/ios-simulator/`; sources are in
+`tools/ios-simulator/helpers/` (MIT, from
+[codex-plusplus-ios-simulator](https://github.com/b-nnett/codex-plusplus-ios-simulator)).
 
-The iPhone-emulator **integration** ships with the IDE (`src-tauri/src/iphone_emulator.rs`
-+ `src/components/IPhoneEmulatorPanel.tsx`). On **macOS** (Apple Silicon, Intel, Hackintosh
-with Xcode), the **iPhone** tab uses a headless **Xcode Simulator mirror** adapted from
-[codex-plusplus-ios-simulator](https://github.com/b-nnett/codex-plusplus-ios-simulator)
-(`src-tauri/src/ios_simulator.rs` + `MacIOSSimulatorPanel.tsx`) — no `Simulator.app`
-window, tap/keyboard/home via CoreSimulator helpers compiled on first use.
+### Windows / Linux
 
-On **Windows/Linux**, the panel drives the **`acheron`** C++ hypervisor (`IPhoneAcheronPanel`),
-streams the serial console + boot logs, captures the display, and feeds touch events back.
-Use the **Legacy** button on macOS if you still want acheron there.
+No hardware-virtualised iOS option exists on non-Apple hosts today. The Rust
+emulator above is the planned path; for now, Windows/Linux users build and
+**deploy to a physical iPhone** — see [Sideloading](#sideloading) and the iOS
+build pipeline in the [README](../README.md#what-you-get).
 
-What is **NOT** in this repository (intentionally — too large / device firmware /
-machine-specific) and must be provided locally:
+## Sideloading to a physical device
 
-| Artifact | Why it's excluded | Where the IDE looks for it |
-|----------|-------------------|----------------------------|
-| `acheron` hypervisor binary | Built per-platform from C++ source | `<project>/build/Release/acheron[.exe]`, `<project>/build/acheron[.exe]`, or on `PATH` |
-| iOS firmware `.ipsw` | ~7–11 GB device firmware (Apple's) | You pass it to `acheron prepare`; output lands in `<project>/out/` |
-| `Virtual-iPhone-Emulator/` app + ramdisk artifacts | Standalone/proprietary, large | Generated into `<project>/out/…` by `acheron prepare` |
+- **[go-ios](https://github.com/danielpaulus/go-ios)** — install and launch `.ipa`
+  builds from any OS, no Xcode.
+- **[AltStore](https://github.com/altstoreio/AltStore)** — not bundled (AGPL);
+  install AltServer separately for 7-day-cert sideload.
 
-> The repo's `.gitignore` excludes `Virtual-iPhone-Emulator/`, `*.ipsw`, and the build
-> output. Cloning gives you a **buildable IDE**; the acheron feature stays idle until you
-> provide these files. On macOS you can use the Xcode Simulator mirror without acheron.
-
----
-
-## macOS — Xcode Simulator mirror (recommended)
-
-Requirements (same as Codex++ tweak):
-
-- Full **Xcode** installed (not Command Line Tools only)
-- `sudo xcode-select -s /Applications/Xcode.app` if needed
-- At least one iOS simulator runtime downloaded in Xcode
-
-Open **Devices → iPhone**, pick a device, click **▶ Mirror**. Helpers compile once to
-`~/Library/Caches/com.hades.vscode-rust-app/ios-simulator/`. Source helpers live in
-`tools/ios-simulator/helpers/` (MIT, from codex-plusplus-ios-simulator).
-
----
-
-## 1. Build the `acheron` hypervisor
-
-`acheron` is a CMake C++ project. From its source directory:
-
-```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --config Release
-```
-
-This produces:
-- Windows: `build/Release/acheron.exe`
-- macOS/Linux: `build/acheron`
-
-Put the binary on your `PATH`, or keep it under the project's `build/` so the IDE's
-`find_acheron()` locates it automatically.
-
-> If you don't have the `acheron` source, obtain it from your private
-> Virtual-iPhone-Emulator repository — it is not redistributed here.
-
-## 2. Get an iOS firmware (`.ipsw`)
-
-Download the **official** restore image for the device/iOS version you want to emulate
-(e.g. from Apple's signing servers / ipsw.me). Only use firmware you are licensed to use.
-
-## 3. Prepare the firmware
-
-`acheron prepare` extracts the real ramdisk + kernelcache + devicetree the emulator boots:
-
-```bash
-acheron prepare --ipsw /path/to/iPhone..._Restore.ipsw --out out
-```
-
-This writes (under `<project>/out/`):
-- `out/raw/initrd.bin` — ramdisk (the IDE auto-fills this as the disk)
-- kernelcache + devicetree (auto-loaded by `acheron run` via `rd=md0`)
-- `out/diagnostics/` — runtime channel: `frame.raw` / `guest_frame.raw` (display),
-  `touch_in.csv` (host→guest pointer)
-
-## 4. Launch from the IDE
-
-Open the **Emulator** panel → it calls `launch_iphone_emulator(project_path)` →
-`acheron run …`, streams `emulator-console` (logs) and `emulator-frame` (display) events,
-and sends touches via `send_iphone_touch`.
-
----
-
-## Expected layout
-
-```
-<project>/
-├── build/
-│   └── Release/acheron.exe        # (or build/acheron on macOS/Linux)
-├── out/
-│   ├── raw/initrd.bin             # from `acheron prepare`
-│   └── diagnostics/               # frame.raw, guest_frame.raw, touch_in.csv
-└── (your .ipsw lives anywhere; pass its path to `acheron prepare`)
-```
-
-## Notes
-- **macOS (Apple Silicon):** the IDE builds and runs without the emulator. To run the
-  emulator you still need an `acheron` macOS build + a firmware you can use.
-- These artifacts are user-provided for legal + size reasons; nothing here distributes
-  Apple firmware or the proprietary emulator app.
+`iPhoneOS.sdk` is the one asset we can't redistribute — supply your own via
+`SDKROOT` or the in-app **Import SDK**.


### PR DESCRIPTION
Rewrites `docs/mobile.md`'s iPhone section and adds credits.

**macOS on Apple Silicon** (M-series, 16–32 GB RAM) now points at two third-party **MIT** projects, credited to their authors:

| Tool | Role |
|------|------|
| [vphone-cli](https://github.com/Lakr233/vphone-cli) by [Lakr233](https://github.com/Lakr233) | Full iPhone emulator **with UI** — the easy path |
| [darwin-vm](https://github.com/jprx/darwin-vm) by [jprx](https://github.com/jprx) | iOS/macOS in **QEMU**, root shell + terminal only |

We don't vendor or redistribute either — users install them and the Devices panel shells out.

**Also:**
- States plainly that VSCodium-Rust's **own** iPhone emulator is a **separate Rust component, still in development**, to be released publicly when finished.
- Drops the stale private-`acheron` C++ hypervisor section and the `vphone-doctor.bat` toolchain notes from the merged doc; keeps the Xcode Simulator mirror as the "if you have full Xcode" option and the sideloading (`go-ios` / AltStore) section.
- README: same framing in the iOS bullet + both projects in the acknowledgements.

`docs/mobile.md`: 164 → ~90 lines.
