### PR TITLE
fix: unblock cargo check on the OSS repo (tauri.conf resources + kortex/turbovec)

### DIFF
--- a/src-tauri/binaries/.gitkeep
+++ b/src-tauri/binaries/.gitkeep
@@ -1,0 +1,3 @@
+# Release binaries (LSP servers, sidecars) are fetched here by
+# scripts/fetch-lsp-binaries.ps1 / build-sidecar.ps1 before `tauri build`.
+# This keeper exists so the tauri.conf.json `binaries/**/*` resource glob resolves.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,18 +59,7 @@
     "resources": [
       "binaries/**/*",
       "ext-host/*",
-      "bundles/*",
-      "../third_party/free-claude-code/server.py",
-      "../third_party/free-claude-code/pyproject.toml",
-      "../third_party/free-claude-code/uv.lock",
-      "../third_party/free-claude-code/.env.example",
-      "../third_party/free-claude-code/api",
-      "../third_party/free-claude-code/cli",
-      "../third_party/free-claude-code/config",
-      "../third_party/free-claude-code/core",
-      "../third_party/free-claude-code/providers",
-      "../third_party/free-claude-code/messaging",
-      "ioscpy/device/**/*"
+      "bundles/*"
     ],
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
`cargo check` currently **fails on `main`** - two fallouts from the #212 open-core curation:

**1. `tauri.conf.json` `bundle.resources` references excluded paths** -> tauri build-script hard-fails (`glob pattern ... didn't match any files`):
- removed 7 `../third_party/free-claude-code/*` entries (dir excluded from OSS)
- removed `ioscpy/device/**/*` (dir excluded)
- added `src-tauri/binaries/.gitkeep` so `binaries/**/*` resolves at dev time (release scripts `fetch-lsp-binaries.ps1` / `build-sidecar.ps1` populate it before `tauri build`)

**2. `kortex` submodule -> `60a2cc84`** (needs **H4D3ZS/kortex#16**): `libaim` used `turbovec::io::MmapIndex`, which only existed in a private turbovec fork whose source is lost; reverted to upstream `IdMapIndex`.

After this, `cd src-tauri && cargo check --lib` passes (36 dead-code warnings, cleaned up in a follow-up).

> Merge order: **H4D3ZS/kortex#16 first**, then re-point the `kortex` submodule here at kortex `main` before merging this (or merge as-is against the branch commit and bump later).