### PR TITLE
fix(mem): dispose Monaco models on bulk close; release WebGL context on avatar teardown

### DIFF
--- a/src/airi/vrm-avatar.ts
+++ b/src/airi/vrm-avatar.ts
@@ -182,6 +182,10 @@ export class AIRIVRMAvatar {
         if (container && this.renderer.domElement.parentElement === container) {
           container.removeChild(this.renderer.domElement);
         }
+        // dispose() alone does not release the WebGL context in Chromium/WebView;
+        // without forceContextLoss() repeated mount/unmount hits the browser's
+        // active-context cap ("Too many active WebGL contexts") and then a crash.
+        this.renderer.forceContextLoss();
         this.renderer.dispose();
       } catch { /* ignore */ }
       this.renderer = null;
@@ -507,6 +511,9 @@ export class AIRIVRMAvatar {
     }
 
     if (this.renderer) {
+      // Force-release the WebGL context (see _cleanupRenderer) — dispose() by
+      // itself leaves it live and the WebView eventually runs out.
+      try { this.renderer.forceContextLoss(); } catch { /* ignore */ }
       this.renderer.dispose();
       this.renderer.domElement.remove();
       this.renderer = null;

--- a/src/store/editorSlice.ts
+++ b/src/store/editorSlice.ts
@@ -5,6 +5,26 @@ import type { AppState } from './index';
 import type { EditorTab, FileEntry, PendingChange, WorkspaceFolder } from './types';
 import { boundedPush, boundedTail, MAX_TAB_HISTORY, MAX_PENDING_CHANGES, MAX_PENDING_CHANGE_CONTENT } from '../domain/utils/boundedArray';
 
+/**
+ * Dispose the Monaco text model backing a file tab. Monaco keeps a model per
+ * opened URI for the app's lifetime unless explicitly disposed, so every
+ * tab-close path must call this or models (and their tokenization state) leak.
+ */
+function disposeTabModel(path: string | undefined): void {
+    if (!path) return;
+    try {
+        const monaco = (window as any).monaco;
+        if (!monaco?.editor) return;
+        const clean = (p: string) => p.replace(/\\/g, '/').replace(/^\//, '').toLowerCase();
+        const target = clean(path);
+        const model = monaco.editor.getModels().find((m: any) => {
+            const mp = clean(m.uri.path);
+            return mp === target || decodeURIComponent(m.uri.toString()).toLowerCase().includes(target);
+        });
+        if (model) model.dispose();
+    } catch { /* best effort */ }
+}
+
 export interface EditorSlice {
     // State
     activeTabId: string | null;
@@ -240,21 +260,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     closeTab: (id: string) => {
         const state = get();
         const tab = state.tabs.find((t: any) => t.id === id);
-        if (tab) {
-            try {
-                const monaco = (window as any).monaco;
-                if (monaco?.editor) {
-                    const models = monaco.editor.getModels();
-                    const cleanPath = (p: string) => p.replace(/\\/g, '/').replace(/^\//, '').toLowerCase();
-                    const targetPath = cleanPath(tab.path);
-                    const model = models.find((m: any) => {
-                        const modelPath = cleanPath(m.uri.path);
-                        return modelPath === targetPath || decodeURIComponent(m.uri.toString()).toLowerCase().includes(targetPath);
-                    });
-                    if (model) model.dispose();
-                }
-            } catch { /* best effort */ }
-        }
+        if (tab) disposeTabModel(tab.path);
         set((state) => {
             const tabs = state.tabs.filter((t: any) => t.id !== id);
             let activeTabId = state.activeTabId;
@@ -332,6 +338,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
     showWelcomeTab: () => {
         try { localStorage.removeItem('welcome.dismissed'); } catch { /* */ }
+        // Bulk tab-clear: dispose every model, otherwise this leaks one Monaco
+        // model per file opened before the workspace switch.
+        for (const t of get().tabs) disposeTabModel((t as any).path);
         set({
             welcomeForceVisible: true,
             tabs: [],


### PR DESCRIPTION
Two WebView memory issues from a static audit (the rest of the audit was clean — stores bounded via `boundedArray`/`MAX_*`, PTY buffers drained at 2000, Rust `VecDeque`s capped, effect cleanup present).

**1. Monaco models leak on workspace switch.** `closeTab()` disposes the model, but `showWelcomeTab()` does `tabs: []` **without** disposing — one text model + tokenization state leaks per file opened before the switch. Extracted `disposeTabModel()`, called for every tab in the bulk-clear path (and reused in `closeTab`).

**2. WebGL context not released on avatar teardown.** `renderer.dispose()` doesn't free the GL context in Chromium/WebView — repeated AIRI-avatar mount/unmount hits the browser's active-context cap ("Too many active WebGL contexts") and then a crash. Added `renderer.forceContextLoss()` before `dispose()` at both teardown sites in `vrm-avatar.ts`.

Static-only (no `node_modules` here) — reviewer: `npm run typecheck`.