### PR TITLE
fix(dev): pre-bundle deps so `tauri dev` stops white-screen reload looping

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,28 @@ export default defineConfig(() => {
         ollama: resolve(import.meta.dirname, 'node_modules/ollama/dist/browser.mjs'),
       },
     },
+    // Pre-bundle everything the (heavily React.lazy'd) app pulls in, so the dev
+    // server doesn't discover a new dep per panel, re-optimize, and force a full
+    // page reload each time — which cascades into a white-screen reload loop.
+    optimizeDeps: {
+      include: [
+        'react', 'react-dom', 'react-dom/client',
+        'zustand', 'zustand/react/shallow',
+        'monaco-editor', '@monaco-editor/react',
+        '@heroui/react',
+        'lucide-react', '@tabler/icons-react',
+        'react-window',
+        'marked', 'react-markdown', 'remark-gfm',
+        'diff', 'dompurify',
+        'reactflow',
+        'three', '@pixiv/three-vrm', '@pixiv/three-vrm-springbone',
+        '@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-canvas', '@xterm/addon-webgl',
+        '@xterm/addon-search', '@xterm/addon-web-links', '@xterm/addon-unicode11',
+        '@tauri-apps/api', '@tauri-apps/api/core', '@tauri-apps/api/event',
+        '@tauri-apps/api/window', '@tauri-apps/api/path',
+        '@tauri-apps/plugin-dialog',
+      ],
+    },
     build: {
       outDir: '../dist',
       emptyOutDir: true,


### PR DESCRIPTION
`vite.config.ts` had no `optimizeDeps`. Given the app's heavy `React.lazy` usage, the dev server discovers a new dependency each time a panel first renders, re-runs esbuild dep-optimization, and issues a **full-page reload**. That re-runs the frontend boot (re-triggering indexing / ext-host / model-list on the backend), which loads more panels, which discovers more deps -> **white screen -> reload, on a loop.**

`optimizeDeps.include` now lists everything the panels pull in (monaco, heroui, reactflow, three/vrm, xterm addons, `@tauri-apps/api` subpaths, markdown, icons, ...), so the server pre-bundles once at startup and never re-optimizes mid-session.

**To test:** `rm -rf node_modules/.vite && npm run dev:full` — first launch pre-bundles (~20-40s), then the window loads and stays.