### PR TITLE
privacy: .mailmap -> GitHub noreply; drop stray personal email

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,9 @@
-# Canonical identity — collapse all author/committer/co-author aliases to one.
-# GitHub applies this to the Contributors graph and `git shortlog -e`.
-H4D3ZS <adingferrer@yahoo.com> <aashleyjanaso2002@gmail.com>
-H4D3ZS <adingferrer@yahoo.com> <zhekary55@gmail.com>
-H4D3ZS <adingferrer@yahoo.com> H4D3ZS <noreply@github.com>
-H4D3ZS <adingferrer@yahoo.com> GitHub <noreply@github.com>
-H4D3ZS <adingferrer@yahoo.com> Cursor <cursoragent@cursor.com>
-H4D3ZS <adingferrer@yahoo.com> Cursor Agent <cursoragent@cursor.com>
+# Canonical identity for `git shortlog -e` and GitHub's Contributors graph.
+# Maps every alias (two personal emails already in history, GitHub web-edit
+# noreply, and the Cursor agent) to the account's GitHub noreply address.
+H4D3ZS <21985514+H4D3ZS@users.noreply.github.com> <adingferrer@yahoo.com>
+H4D3ZS <21985514+H4D3ZS@users.noreply.github.com> <aashleyjanaso2002@gmail.com>
+H4D3ZS <21985514+H4D3ZS@users.noreply.github.com> H4D3ZS <noreply@github.com>
+H4D3ZS <21985514+H4D3ZS@users.noreply.github.com> GitHub <noreply@github.com>
+H4D3ZS <21985514+H4D3ZS@users.noreply.github.com> Cursor <cursoragent@cursor.com>
+H4D3ZS <21985514+H4D3ZS@users.noreply.github.com> Cursor Agent <cursoragent@cursor.com>


### PR DESCRIPTION
`.mailmap` isn't where the emails come from — `adingferrer@yahoo.com` is in **219 author / 203 committer** commit objects on `main`, and `aashleyjanaso2002@gmail.com` in 2. `.mailmap` only changes what `git shortlog` / GitHub's Contributors graph *display*.

**This PR:**
- **removes `zhekary55@gmail.com`** — it was in **no commit at all**, only added exposure sitting in the mailmap file
- canonical identity is now `21985514+H4D3ZS@users.noreply.github.com` (the account's GitHub noreply) instead of the personal yahoo address

`git shortlog -sne` now shows one contributor at the noreply address.

**To actually remove the personal emails from history** (separate, opt-in): a `git filter-repo --email-callback` pass rewriting every commit's author+committer email to the noreply address, then force-push `main`. Changes all SHAs; old emails still linger in GitHub's ~90-day cache, existing clones/forks, and SHA-addressable dangling objects. Also enable **GitHub → Settings → Emails → "Keep my email addresses private"** + **"Block command line pushes that expose my email"**, and set `git config user.email 21985514+H4D3ZS@users.noreply.github.com` so future commits stop adding it.