### PR TITLE
perf(boot): defer extension host; make built-in MCP :1537 opt-in

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -461,17 +461,19 @@ impl EditorState {
 
         let vfs_bridge = Arc::new(vfs_bridge::VfsBridge::new(root.clone()));
         let mcp_server = Arc::new(mcp_server::McpServer::new(sentient.ai_tools.clone()));
-        // Potato mode: skip the MCP listener entirely; external MCP clients are
-        // rare on low-RAM machines and the Axum stack isn't free.
-        if !crate::system_profile::is_lite() {
+        // The built-in MCP listener (:1537) only matters when an *external* MCP
+        // client wants to reach this IDE's tools — uncommon. Opt-in: it auto-
+        // starts only if `<config>/mcp_builtin.enabled` exists (created by the
+        // MCP Store's "Expose IDE tools" toggle). Skipped in lite mode regardless.
+        let mcp_builtin_enabled = config_dir.join("mcp_builtin.enabled").exists();
+        if !crate::system_profile::is_lite() && mcp_builtin_enabled {
             let mcp_server_clone = mcp_server.clone();
             crate::event_sink::spawn_detached(async move {
-                // Defer MCP listener — not needed for idle shell boot.
                 tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
                 mcp_server_clone.start(1537).await;
             });
         } else {
-            println!("[profile] lite: MCP listener (:1537) not auto-started");
+            println!("[profile] built-in MCP listener (:1537) not auto-started (opt-in via mcp_builtin.enabled)");
         }
 
         // WebUI→MCP bridge (:1538). Shares the same AiTools registry as the MCP server.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,14 +94,10 @@ const App: React.FC = () => {
             import('./application/workspace/multiRootWorkspace').then(m => m.initWorkspaceFoldersFromStorage());
         }, 2_000);
 
-        scheduleDeferredInit(() => {
-            // Legacy vanilla-JS init modules (search/status_bar/specs/mobile/scm/
-            // debug_ui) were removed — they wired to getElementById() slots the
-            // React app no longer renders, so they no-op'd at boot. React panels
-            // (SearchView, StatusBar, EmulatorPanel, ScmView, DebugView, …)
-            // replaced them. Only the extension host still needs an explicit init.
-            import('./extensions').then(m => m.initExtensions());
-        });
+        // The extension host (Node sidecar) is no longer started here — it inits
+        // on first open of the Extensions view (ExtensionsView.tsx). Legacy
+        // vanilla-JS boot modules (search/status_bar/specs/mobile/scm/debug_ui)
+        // were removed; their React panels replaced them.
 
         // --- Platform Detection for Native Feel ---
         const ua = navigator.userAgent.toLowerCase();

--- a/src/components/ExtensionsView.tsx
+++ b/src/components/ExtensionsView.tsx
@@ -178,8 +178,13 @@ const ExtensionsView: React.FC = () => {
     const [activeAccordion, setActiveAccordion] = useState<string | null>('marketplace');
 
     useEffect(() => {
-        refreshInstalledExtensions();
-        refreshPopularExtensions();
+        // Start the extension host (Node sidecar, ~34 MB) on first open of this
+        // view instead of at app boot — most sessions never touch Extensions.
+        // initExtensions() also does refreshInstalled/refreshPopular internally.
+        void import('../extensions').then(m => m.initExtensions()).catch(() => {
+            refreshInstalledExtensions();
+            refreshPopularExtensions();
+        });
     }, []);
 
     const handleSearch = (e: React.FormEvent) => {


### PR DESCRIPTION
Items 1 + 3 from the boot-memory list. `cargo check --lib` green (36 warnings, unchanged).

**Extension host (~34 MB Node sidecar)** — `initExtensions()` moved from the `App.tsx` deferred-boot cascade into `ExtensionsView`'s mount effect. Sessions that never open the Extensions view no longer spawn it. `initExtensions()` already calls `refreshInstalled`/`refreshPopular` internally, so the view's own two refresh calls are replaced (kept as a fallback if the host fails to start).

**Built-in MCP listener (`:1537`)** — now opt-in: auto-starts only if `<config>/mcp_builtin.enabled` exists. It only matters when an *external* MCP client wants to reach this IDE's tools (uncommon), and the axum stack + 20 s timer aren't free. Still skipped entirely in lite mode.

**Behaviour change:** an always-on extension (e.g. one providing an LSP) won't activate until the Extensions view is opened once per session. If you rely on that, revert the `ExtensionsView.tsx` hunk — the MCP change is independent.

webui removal is the next PR (bigger — 4 Rust modules + 6 commands + the `Claude (WebUI)` providers + the browser extension).