### PR TITLE
perf(boot): stop auto-starting WebUI bridge (:1538) + web-chat shim (:1539)

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -474,37 +474,15 @@ impl EditorState {
             println!("[profile] lite: MCP listener (:1537) not auto-started");
         }
 
-        // WebUI→MCP bridge (:1538). Shares the same AiTools registry as the MCP server.
-        // The browser extension connects here so free web-chat models drive real tools.
+        // WebUI web-chat feature (browser-session scraping) is disabled — it never
+        // worked reliably and the frontend picker gates it off (WEBUI_MODELS_ENABLED
+        // = false). The bridge (:1538) and OpenAI shim (:1539) no longer auto-start;
+        // the handle/driver are still constructed for the (unused) webchat_* commands.
         let webui_bridge = crate::infrastructure::webui_mcp_bridge::WebUiBridge::new(
             sentient.ai_tools.clone(),
         );
-        if !crate::system_profile::is_lite() {
-            let bridge_clone = webui_bridge.clone();
-            crate::event_sink::spawn_detached(async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
-                bridge_clone
-                    .start(crate::infrastructure::webui_mcp_bridge::BRIDGE_PORT)
-                    .await;
-            });
-        } else {
-            println!("[profile] lite: WebUI bridge (:1538) not auto-started");
-        }
-
-        // Headless web-chat driver + OpenAI shim (:1539). Own dedicated browser
-        // sidecar so the agent's browser tools never hijack the chat session.
         let web_chat = crate::infrastructure::web_chat_driver::WebChatDriver::new(&config_dir);
         app.manage(std::sync::Arc::clone(&web_chat)); // State<Arc<WebChatDriver>> for webchat_login
-        if !crate::system_profile::is_lite() {
-            let shim = crate::infrastructure::webchat_openai_shim::WebChatShim::new(web_chat.clone());
-            crate::event_sink::spawn_detached(async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
-                shim.start(crate::infrastructure::webchat_openai_shim::WEBCHAT_SHIM_PORT)
-                    .await;
-            });
-        } else {
-            println!("[profile] lite: web-chat shim (:1539) not auto-started");
-        }
 
         // Shared diagnostics map — owned by EditorState, borrowed by LspClient
         let shared_lsp_diags: lsp::DiagnosticsMap =


### PR DESCRIPTION
**WebUI removal, phase 1.** The 'personal subscription / browser-session scraping' feature never worked reliably and the frontend already disables it (`WEBUI_MODELS_ENABLED = false`).

Removes the two 20s-deferred `spawn_detached` blocks in `state.rs` so **no session opens `:1538` (bridge), `:1539` (OpenAI shim), or the dedicated web-chat browser sidecar**.

The `WebUiBridge` handle + `WebChatDriver` are still constructed — the `EditorState` field, the autonomous supervisor's `bridge` plumbing, and the `webchat_*` commands still reference them — so nothing else breaks. `cargo check --lib` green, 36 warnings unchanged.

**Phase 2 (follow-up):** delete `webui_bridge.rs` / `webui_protocol.rs` / `webchat_openai_shim.rs` / `webui_mcp_bridge.rs`, the 6 `webui_bridge_*` / `webchat_*` commands from `invoke_handler!`, the `webui_bridge` field + supervisor `bridge` plumbing, the disabled provider list, and `extensions/webui-bridge/`.